### PR TITLE
Use kill command for shutting down dev server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ tail:
 	tail -f .server.logs
 
 kill:
-	-pkill -P $$(cat .server)
+	-kill $$(cat .server)
 
 venv: .venv
 .venv: requirements-test.in


### PR DESCRIPTION
The pkill command we were using does not seem to be able to successfully kill the flask process. 