### PR TITLE
Disable 'Accept All Cookies' button when a 'Do Not Track' signal is received

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ddriddle @edthedev @mpitcel @tzturner @zdc217

--- a/src/web/css/ila-cookie-banner.css
+++ b/src/web/css/ila-cookie-banner.css
@@ -127,6 +127,10 @@
     background-color: var(--ila-cookieb-accent);
     color: var(--ila-cookieb-hover-button-font);
 }
+.ila-cookieb__button:disabled {
+	background-color: gray;
+	pointer-events: none;
+}
 
 .ila-cookieb__close-icon {
     padding: var(--ila-cookieb-padding-y) var(--ila-cookieb-padding-x);

--- a/src/web/js/ila-cookie-banner.js
+++ b/src/web/js/ila-cookie-banner.js
@@ -8,10 +8,34 @@ if (window.location.hostname === 'localhost' || window.location.hostname === '12
 
 var this_script = document.currentScript; // Must run before any function calls
 
+async function check_do_not_track() {
+	// check whether the browser support Do not track
+	if (navigator.doNotTrack || window.doNotTrack || navigator.globalPrivacyControl) {
+		// if it supports
+		// then check for the doNotTrack property in each known case
+		if (
+			window.doNotTrack === "1" ||
+			navigator.doNotTrack === "1" ||
+			navigator.doNotTrack === "yes" || 
+			navigator.globalPrivacyControl === true
+		) {
+			// the options is enabled
+			console.log("Obeying browser 'Do not track' signal");
+		} else {
+			// the option is not enabled
+			console.log("Do not track checked, and not found");
+		}
+	} else {
+		console.log("No recognized 'do not track' found");
+	}
+}
+
 async function openCookieB(cookiebId) {
     // Do not show if our 'dismiss' cookie is set
     let skip = await getDismissCookieNotice();
     if(skip) { return; }
+
+		check_do_not_track();
 
     let cookieb = document.getElementById(cookiebId);
     cookieb.classList.remove('ila-cookieb--closed');

--- a/src/web/js/ila-cookie-banner.js
+++ b/src/web/js/ila-cookie-banner.js
@@ -8,7 +8,7 @@ if (window.location.hostname === 'localhost' || window.location.hostname === '12
 
 var this_script = document.currentScript; // Must run before any function calls
 
-async function check_do_not_track() {
+function check_do_not_track() {
 	// check whether the browser support Do not track
 	if (navigator.doNotTrack || window.doNotTrack || navigator.globalPrivacyControl) {
 		// if it supports
@@ -21,12 +21,15 @@ async function check_do_not_track() {
 		) {
 			// the options is enabled
 			console.log("Obeying browser 'Do not track' signal");
+			return true;
 		} else {
 			// the option is not enabled
 			console.log("Do not track checked, and not found");
+			return false;
 		}
 	} else {
 		console.log("No recognized 'do not track' found");
+		return false;
 	}
 }
 
@@ -35,7 +38,13 @@ async function openCookieB(cookiebId) {
     let skip = await getDismissCookieNotice();
     if(skip) { return; }
 
-		check_do_not_track();
+		if (check_do_not_track() === true) {
+			/* If sent 'Do Not Track', then disable 'Accept All', and show explanation. */
+			let acceptButton = document.getElementById('ilaCookieAcceptButton');
+			acceptButton.disabled = true;
+			let doNotTrackText = document.getElementById('ilaCookieDoNotTrackText');
+			doNotTrackText.hidden = false;
+		}
 
     let cookieb = document.getElementById(cookiebId);
     cookieb.classList.remove('ila-cookieb--closed');
@@ -270,7 +279,7 @@ function createCookieNoticeFocusCycle() {
             e.preventDefault();
         }});
 
-    last = document.getElementById("ilaCookieCloseButton");
+    last = document.getElementById("ilaCookieRejectButton");
     last.addEventListener('keydown', function(e){
         if (e.keyCode===9 && !e.shiftKey) {
             first.focus();

--- a/src/web/partials/ila-cookie-banner-content.part.html
+++ b/src/web/partials/ila-cookie-banner-content.part.html
@@ -30,17 +30,23 @@
                             <span>Link opens in a new window</span>
                         </a>
                     </p>
+										<p id="ilaCookieDoNotTrackText">
+										<br/>
+										<strong>'Accept All Cookies' is disabled to respect a 'Do Not Track' signal from your browser.
+										Click 'Reject Non-Essential Cookies' or the 'X' to proceed.
+										</strong>
+										</p>
                     <div class="ila-cookieb__actions">
                         <button id="ilaCookieAboutButton" type="button" class="ila-cookieb__button"
                         data-cookie-action="open-about">
                             About Cookies
                         </button>
-                        <button id="ilaCookieCloseButton" type="button" class="ila-cookieb__button"
-                        aria-label="close cookie notice" data-cookie-action="close-banner-granted">
+                        <button id="ilaCookieAcceptButton" type="button" class="ila-cookieb__button"
+                        aria-label="accept all cookies and close cookie notice" data-cookie-action="close-banner-granted">
                             Accept All Cookies
                         </button>
-                        <button id="ilaCookieCloseButton" type="button" class="ila-cookieb__button"
-                        aria-label="close cookie notice" data-cookie-action="close-banner-denied">
+                        <button id="ilaCookieRejectButton" type="button" class="ila-cookieb__button"
+                        aria-label="reject non-essential cookies and close cookie notice" data-cookie-action="close-banner-denied">
                             Reject Non-Essential Cookies
                         </button>
                     </div>

--- a/src/web/partials/ila-cookie-banner-content.part.html
+++ b/src/web/partials/ila-cookie-banner-content.part.html
@@ -30,7 +30,7 @@
                             <span>Link opens in a new window</span>
                         </a>
                     </p>
-										<p id="ilaCookieDoNotTrackText">
+										<p id="ilaCookieDoNotTrackText" hidden>
 										<br/>
 										<strong>'Accept All Cookies' is disabled to respect a 'Do Not Track' signal from your browser.
 										Click 'Reject Non-Essential Cookies' or the 'X' to proceed.


### PR DESCRIPTION
- Check for various 'Do Not Track' signals
- Disable the 'Accept All Cookies' button when signal is received
- Display explanation text when 'Accept All Cookies' button is disabled
- Add CODEOWNERS file

Closes #10